### PR TITLE
Fixed route error when opening day page

### DIFF
--- a/fields/calendarboard/controller.php
+++ b/fields/calendarboard/controller.php
@@ -30,7 +30,7 @@ class CalendarboardFieldController extends Kirby\Panel\Controllers\Field {
     $this->field()->check_day($this->model(), $date);
     
     // Go to day edit page
-    go(purl($this->model(), 'year-' . $Date[0] . '/day-' . $date . '/edit/'));  
+    go(purl($this->model(), 'year-' . $Date[0] . '/day-' . $date . '/edit'));  
   }  
 
 }


### PR DESCRIPTION
The slash at the end of the url caused a routing error